### PR TITLE
Fix wrong implementation of negating a polygon

### DIFF
--- a/Algorithm_Implementations_Cpp/Geometry/Convex_Polygon/convex_polygon.sublime-snippet
+++ b/Algorithm_Implementations_Cpp/Geometry/Convex_Polygon/convex_polygon.sublime-snippet
@@ -115,8 +115,7 @@ struct convex_polygon{
 	}
 	// O(n)
 	convex_polygon operator-() const{
-		convex_polygon res;
-		reverse(res.data.begin(), res.data.end());
+		convex_polygon res = *this;
 		for(auto &p: res.data) p = -p;
 		rotate(res.data.begin(), min_element(res.data.begin(), res.data.end()), res.data.end());
 		return res;


### PR DESCRIPTION
In the convex_polygon <T>::operator-() function, res is not initialized as *this, causing res.data to be empty.

Also, reversing res.data is wrong: its orientation should stays the same, because (-a) ^ (-b) = a ^ b.

Got accepted using the corrected version at https://acm.timus.ru/problem.aspx?space=1&num=1894